### PR TITLE
Explicitly compute code coverage for the library

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,13 +42,13 @@ jobs:
         pylint modern_python_package
 
     - run: |
-        python -m build --wheel
-
-    - run: |
         pytest
 
     - run: |
         pyright
+
+    - run: |
+        python -m build --wheel
 
     - uses: haya14busa/action-cond@v1
       id: singleton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ good-names=["rv"]
 
 # https://docs.pytest.org/en/7.1.x/reference/customize.html#pyproject-toml
 [tool.pytest.ini_options]
-addopts = "--cov --junitxml=coverage.xml --cov-fail-under=80"
+addopts = "--cov=modern_python_package --junitxml=coverage.xml --cov-fail-under=80"
 
 # https://github.com/microsoft/pyright/blob/main/docs/configuration.md#sample-pyprojecttoml-file
 [tool.pyright]

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+# https://stackoverflow.com/a/60579142

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,5 @@
+from modern_python_package.cli import main
+
+
+def test_main():
+    main()


### PR DESCRIPTION
Closes #11.

Strangely, test coverage is 0 if you build the wheel before running `pytest`.